### PR TITLE
perf: parallelization

### DIFF
--- a/doc-exporter-mod/src/main/java/dev/qther/doc_exporter/AnimatedTextureExporter.java
+++ b/doc-exporter-mod/src/main/java/dev/qther/doc_exporter/AnimatedTextureExporter.java
@@ -3,10 +3,14 @@ package dev.qther.doc_exporter;
 import dev.qther.doc_exporter.mixin.AnimatedTextureAccessor;
 import dev.qther.doc_exporter.mixin.AnimatedTextureFramesAccessor;
 import dev.qther.doc_exporter.mixin.FrameInfoAccessor;
+import dev.qther.doc_exporter.mixin.SpriteContentsAccessor;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectSets;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.SpriteContents;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.neoforged.neoforge.client.model.data.ModelData;
 import org.slf4j.Logger;
@@ -16,10 +20,11 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Exports animated item textures as GIF files using Minecraft's animation system.
@@ -62,28 +67,36 @@ public class AnimatedTextureExporter {
     public static void exportAnimatedTextures(String modId) {
         Path baseOutputDir = ExportPaths.BASE.resolve("animated_textures");
 
-        int exportedCount = 0;
         Minecraft minecraft = Minecraft.getInstance();
+
+        var phaser = new Phaser(1);
+        var exported = new AtomicInteger();
 
         for (Item item : BuiltInRegistries.ITEM) {
             if (!isItemFromMod(item, modId)) {
                 continue;
             }
 
-            try {
-                TextureAtlasSprite sprite = getItemSprite(minecraft, item);
+            TextureAtlasSprite sprite = getItemSprite(minecraft, item);
 
-                if (isAnimated(sprite)) {
-                    processAnimatedItem(item, sprite, baseOutputDir);
-                    exportedCount++;
-                }
-            } catch (Exception e) {
-                LOGGER.debug("Failed to check item {} for animation: {}",
-                    BuiltInRegistries.ITEM.getKey(item), e.getMessage());
+            if (isAnimated(sprite)) {
+                phaser.register();
+                DocExportHelper.executor.submit(() -> {
+                    try {
+                        processAnimatedItem(item, sprite, baseOutputDir);
+                    } catch (IOException e) {
+                        LOGGER.debug("Failed to check item {} for animation: {}",
+                                BuiltInRegistries.ITEM.getKey(item), e.getMessage());
+                    }
+                    exported.incrementAndGet();
+                    phaser.arriveAndDeregister();
+                });
             }
         }
 
-        LOGGER.info("Exported {} animated textures for mod {}", exportedCount, modId);
+        phaser.arriveAndAwaitAdvance();
+
+        LOGGER.info("Exported {} animated textures for mod {}", exported.get(), modId);
     }
 
     private static boolean isItemFromMod(Item item, String modId) {
@@ -92,14 +105,16 @@ public class AnimatedTextureExporter {
 
     private static TextureAtlasSprite getItemSprite(Minecraft minecraft, Item item) {
         return minecraft.getItemRenderer()
-            .getItemModelShaper()
-            .getItemModel(item.getDefaultInstance())
-            .getParticleIcon(ModelData.EMPTY);
+                .getItemModelShaper()
+                .getItemModel(item.getDefaultInstance())
+                .getParticleIcon(ModelData.EMPTY);
     }
 
     private static boolean isAnimated(TextureAtlasSprite sprite) {
         return sprite.contents().getUniqueFrames().count() > 1;
     }
+
+    private static final Set<ResourceLocation> PROCESSED = ObjectSets.synchronize(new ObjectOpenHashSet<>());
 
     /**
      * Processes a single animated item by extracting its frames and generating a GIF.
@@ -108,7 +123,12 @@ public class AnimatedTextureExporter {
     private static void processAnimatedItem(Item item, TextureAtlasSprite sprite, Path baseOutputDir) throws IOException {
         // Get the actual texture name from the sprite (e.g., "minecraft:item/diamond_sword")
         SpriteContents spriteContents = sprite.contents();
-        net.minecraft.resources.ResourceLocation textureName = ((dev.qther.doc_exporter.mixin.SpriteContentsAccessor) spriteContents).getName();
+        ResourceLocation textureName = ((SpriteContentsAccessor) spriteContents).getName();
+
+        if (!PROCESSED.add(textureName)) {
+            LOGGER.error("GIF for texture {} already generated or generating, skipping", textureName);
+            return;
+        }
 
         String textureNamespace = textureName.getNamespace();
         String texturePath = textureName.getPath();
@@ -130,8 +150,8 @@ public class AnimatedTextureExporter {
 
     private static void writeErrorPlaceholder(Path outputDir, String textureName, Exception error) throws IOException {
         String errorMessage = String.format(
-            "Failed to generate GIF for texture: %s. Error: %s",
-            textureName, error.getMessage());
+                "Failed to generate GIF for texture: %s. Error: %s",
+                textureName, error.getMessage());
 
         Path placeholderPath = outputDir.resolve(textureName + ".gif.txt");
         Files.writeString(placeholderPath, errorMessage);
@@ -279,7 +299,7 @@ public class AnimatedTextureExporter {
      *
      * @param frame1 The first frame (at t=0)
      * @param frame2 The second frame (at t=1)
-     * @param t Interpolation factor (0.0 = fully frame1, 1.0 = fully frame2)
+     * @param t      Interpolation factor (0.0 = fully frame1, 1.0 = fully frame2)
      * @return A new BufferedImage with interpolated pixel values
      */
     private static BufferedImage interpolateFrames(BufferedImage frame1, BufferedImage frame2, float t) {
@@ -333,7 +353,7 @@ public class AnimatedTextureExporter {
     /**
      * Scales an image using nearest neighbor interpolation to preserve pixel art appearance.
      *
-     * @param source The source image to scale
+     * @param source      The source image to scale
      * @param scaleFactor The integer scale factor (2 = double size, 8 = 16x16 to 128x128)
      * @return A new BufferedImage scaled up by the given factor
      */

--- a/doc-exporter-mod/src/main/java/dev/qther/doc_exporter/DocExportHelper.java
+++ b/doc-exporter-mod/src/main/java/dev/qther/doc_exporter/DocExportHelper.java
@@ -1,9 +1,13 @@
 package dev.qther.doc_exporter;
 
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.hollingsworth.arsnouveau.api.documentation.export.DocExporter;
 import com.hollingsworth.arsnouveau.api.registry.GlyphRegistry;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import net.minecraft.client.Minecraft;
 import net.minecraft.locale.Language;
 import net.minecraft.world.level.Level;
@@ -15,6 +19,7 @@ import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforgespi.language.IModInfo;
+import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,12 +29,18 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 @Mod(DocExportHelper.MODID)
 public class DocExportHelper {
     public static final String MODID = "doc_exporter";
     public static final Logger LOGGER = LoggerFactory.getLogger(MODID);
     public boolean exported = false;
+
+    public static final ExecutorService executor = Executors.newCachedThreadPool();
 
     public DocExportHelper(IEventBus modEventBus, ModContainer modContainer) {
         NeoForge.EVENT_BUS.addListener(EventPriority.LOWEST, this::postTick);
@@ -68,41 +79,75 @@ public class DocExportHelper {
             LOGGER.error("could not create glyphs file", e);
         }
 
-        // Export lang
-        try {
-            Path langDir = ExportPaths.langBase();
-            Files.createDirectories(langDir);
+        var langExport = new Thread(() -> {
+            // Export lang
+            try {
+                Path langDir = ExportPaths.langBase();
+                Files.createDirectories(langDir);
 
-            for (String langCode : Minecraft.getInstance().getLanguageManager().getLanguages().keySet()) {
-                Path langPath = ExportPaths.langFile(langCode);
+                var languages = Minecraft.getInstance().getLanguageManager().getLanguages();
+                var sw = Stopwatch.createStarted();
 
-                LOGGER.info("Exporting language {}", langCode);
-                if (!LangExporter.loadLanguage(langCode)) {
-                    continue;
+                for (String langCode : languages.keySet()) {
+                    Path langPath = ExportPaths.langFile(langCode);
+
+                    if (!LangExporter.loadLanguage(langCode)) {
+                        continue;
+                    }
+
+                    LOGGER.info("Exporting language {}", langCode);
+                    var langMap = new TreeMap<>(Language.getInstance().getLanguageData());
+                    JsonElement jsonEl = LangExporter.buildLangJson(langMap);
+                    executor.submit(() -> {
+                        try {
+                            Files.writeString(langPath, jsonEl.toString(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                        } catch (IOException e) {
+                            LOGGER.error("Could not create lang file for {}", langCode, e);
+                        }
+                    });
                 }
-                try (java.io.BufferedWriter writer = Files.newBufferedWriter(langPath, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
-                    JsonElement jsonEl = LangExporter.buildLangJson(Language.getInstance().getLanguageData());
-                    writer.append(jsonEl.toString());
-                }
-                LOGGER.info("Exported language {}", langCode);
+                LOGGER.info("Exported {} lang files in {}", languages.size(), DurationFormatUtils.formatDurationHMS(sw.elapsed().toMillis()));
+            } catch (IOException | IllegalStateException e) {
+                LOGGER.error("could not create lang files", e);
             }
-        } catch (IOException | IllegalStateException e) {
-            LOGGER.error("could not create lang files", e);
+
+            LangExporter.loadLanguage("en_us");
+        });
+
+        var animatedTextureExport = new Thread(() -> {
+            // Export animated textures
+            try {
+                Path animatedTexturesBase = ExportPaths.animatedTexturesBase();
+                Files.createDirectories(animatedTexturesBase);
+
+                var mods = ModList.get().getMods();
+                var latch = new CountDownLatch(mods.size());
+                var sw = Stopwatch.createStarted();
+                for (IModInfo mod : mods) {
+                    LOGGER.info("Exporting animated textures for {}", mod.getModId());
+                    executor.submit(() -> {
+                        AnimatedTextureExporter.exportAnimatedTextures(mod.getModId());
+                        latch.countDown();
+                    });
+                }
+                latch.await();
+                LOGGER.info("Exported animated textures in {}", DurationFormatUtils.formatDurationHMS(sw.elapsed().toMillis()));
+            } catch (IOException | IllegalStateException | InterruptedException e) {
+                LOGGER.error("could not create animated textures", e);
+            }
+        });
+
+        langExport.start();
+        animatedTextureExport.start();
+        try {
+            langExport.join();
+        } catch (InterruptedException e) {
+            LOGGER.error("Lang export interrupted", e);
         }
-
-        LangExporter.loadLanguage("en_us");
-
-        // Export animated textures
         try {
-            Path animatedTexturesBase = ExportPaths.animatedTexturesBase();
-            Files.createDirectories(animatedTexturesBase);
-
-            for (IModInfo mod : ModList.get().getMods()) {
-                LOGGER.info("Exporting animated textures for {}", mod.getModId());
-                AnimatedTextureExporter.exportAnimatedTextures(mod.getModId());
-            }
-        } catch (IOException | IllegalStateException e) {
-            LOGGER.error("could not create animated textures", e);
+            animatedTextureExport.join();
+        } catch (InterruptedException e) {
+            LOGGER.error("Animated texture export interrupted", e);
         }
 
         // Exit

--- a/doc-exporter-mod/src/main/java/dev/qther/doc_exporter/GifGenerator.java
+++ b/doc-exporter-mod/src/main/java/dev/qther/doc_exporter/GifGenerator.java
@@ -75,7 +75,6 @@ public class GifGenerator {
 
             writer.endWriteSequence();
             writer.dispose();
-            output.flush();
         }
 
         // Manually insert NETSCAPE 2.0 loop extension
@@ -134,7 +133,6 @@ public class GifGenerator {
             out.write(gifData, 0, pos); // Write everything up to insertion point
             out.write(loopExtension); // Insert loop extension
             out.write(gifData, pos, gifData.length - pos); // Write rest of GIF
-            out.flush();
         }
     }
 }

--- a/doc-exporter-mod/src/main/java/dev/qther/doc_exporter/GifGenerator.java
+++ b/doc-exporter-mod/src/main/java/dev/qther/doc_exporter/GifGenerator.java
@@ -1,5 +1,7 @@
 package dev.qther.doc_exporter;
 
+import com.google.common.base.Stopwatch;
+import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +34,7 @@ public class GifGenerator {
         // Create temporary file to write GIF without loop extension first
         Path tempPath = outputPath.getParent().resolve(outputPath.getFileName() + ".tmp");
 
+        Stopwatch sw = Stopwatch.createStarted();
         try (FileImageOutputStream output = new FileImageOutputStream(tempPath.toFile())) {
             ImageWriter writer = ImageIO.getImageWritersByFormatName("gif").next();
             writer.setOutput(output);
@@ -68,12 +71,11 @@ public class GifGenerator {
 
                 IIOImage iioImage = new IIOImage(frame, null, imageMetadata);
                 writer.writeToSequence(iioImage, writeParam);
-
-                LOGGER.debug("Frame {} delay: {}ms ({}x{})", i, delayMs, frame.getWidth(), frame.getHeight());
             }
 
             writer.endWriteSequence();
             writer.dispose();
+            output.flush();
         }
 
         // Manually insert NETSCAPE 2.0 loop extension
@@ -82,7 +84,7 @@ public class GifGenerator {
         // Delete temporary file
         Files.deleteIfExists(tempPath);
 
-        LOGGER.info("Successfully wrote GIF with infinite loop to {}", outputPath);
+        LOGGER.info("Successfully wrote GIF with infinite loop to {} in {}", outputPath, DurationFormatUtils.formatDurationHMS(sw.elapsed().toMillis()));
     }
 
     /**
@@ -132,6 +134,7 @@ public class GifGenerator {
             out.write(gifData, 0, pos); // Write everything up to insertion point
             out.write(loopExtension); // Insert loop extension
             out.write(gifData, pos, gifData.length - pos); // Write rest of GIF
+            out.flush();
         }
     }
 }

--- a/doc-exporter-mod/src/main/java/dev/qther/doc_exporter/LangExporter.java
+++ b/doc-exporter-mod/src/main/java/dev/qther/doc_exporter/LangExporter.java
@@ -32,13 +32,8 @@ public final class LangExporter {
         }
     }
 
-    public static JsonElement buildLangJson(Map<String, String> langData) {
-        Codec<Map<String, String>> s2sMapCodec = Codec.unboundedMap(Codec.STRING, Codec.STRING);
-        TreeMap<String, String> sorted = new TreeMap<>(langData);
-        return s2sMapCodec.encodeStart(JsonOps.INSTANCE, sorted).getOrThrow();
-    }
-
-    public static JsonElement buildCurrentLanguageJson() {
-        return buildLangJson(Language.getInstance().getLanguageData());
+    private static final Codec<Map<String, String>> s2sMapCodec = Codec.unboundedMap(Codec.STRING, Codec.STRING);
+    public static JsonElement buildLangJson(TreeMap<String, String> langData) {
+        return s2sMapCodec.encodeStart(JsonOps.INSTANCE, langData).getOrThrow();
     }
 }


### PR DESCRIPTION
runs lang and animated texture export in parallel and makes animated texture export export each texture in its own thread (from a pool).

strangely, prismarine seems to consistently take extremely long (>10s on my machine) compared to all the others (< 0.5s each)