### PR TITLE
fix: make tmg, omega, scalaes, and trinkets count as NEG items for animated texture export

### DIFF
--- a/doc-exporter-mod/src/main/java/dev/qther/doc_exporter/AnimatedTextureExporter.java
+++ b/doc-exporter-mod/src/main/java/dev/qther/doc_exporter/AnimatedTextureExporter.java
@@ -100,7 +100,8 @@ public class AnimatedTextureExporter {
     }
 
     private static boolean isItemFromMod(Item item, String modId) {
-        return BuiltInRegistries.ITEM.getKey(item).getNamespace().equals(modId);
+        var itemNamespace = BuiltInRegistries.ITEM.getKey(item).getNamespace();
+        return itemNamespace.equals(modId) || (modId.equals("not_enough_glyphs") && itemNamespace.matches("^(toomanyglyphs|arsomega|ars_scalaes|ars_trinkets)$"));
     }
 
     private static TextureAtlasSprite getItemSprite(Minecraft minecraft, Item item) {


### PR DESCRIPTION
untested due to github actions not being able to consistently reach docker hub